### PR TITLE
Prerequisite Update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Is your OpenStack installation ready to run BOSH and install Cloud Foundry? Run 
 ### OpenStack
 
 * Keystone v3
+* Cinder v2
 * Create an OpenStack project/tenant
 * Create a network
   * Connect the network with a router to your external network
@@ -20,7 +21,7 @@ Is your OpenStack installation ready to run BOSH and install Cloud Foundry? Run 
 $ ssh-keygen -t rsa -b 4096 -N "" -f cf-validator.rsa_id
 ```
   * Upload the generated public key to OpenStack as `cf-validator`
-  
+
 * A public image available in glance
   * If your OpenStack installation doesn't yet provide any image, you can upload a [CirrOS test image](http://docs.openstack.org/image-guide/obtain-images.html#cirros-test)
 
@@ -63,7 +64,7 @@ $ ./validate --stemcell bosh-stemcell-<xxx>-openstack-kvm-ubuntu-trusty-go_agent
 
 ## Configure CPI used by validator
 
-Validator downloads CPI release from the URL specified in the validator configuration. You can override this by specifying the `--cpi-release` command line option with the path to a CPI release tarball. 
+Validator downloads CPI release from the URL specified in the validator configuration. You can override this by specifying the `--cpi-release` command line option with the path to a CPI release tarball.
 
 If you already have a CPI compiled, you can specify the path to the executable in the environment variable `OPENSTACK_CPI_BIN`. This is used when no CPI release is specified on the command line. It overrides the setting in the validator configuration file.
 


### PR DESCRIPTION
Cinder V1 produced following error:

```

Your OpenStack
  API
    rate limit
      is high enough... passed
    Security groups
      has ingress rule for SSH... passed
      has egress rule for HTTP... passed
      has egress rule for DNS... passed
  using the CPI
    can save a stemcell... passed
    can create a VM... passed
    has VM cid... passed
    can set VM metadata... passed
    can create a disk in same AZ as VM... failed

Failures:

  1) Your OpenStack using the CPI can create a disk in same AZ as VM
     Failure/Error: fail("#{error_message} OpenStack error: #{e.message}")

     RuntimeError:
       Disk could not be created. OpenStack error: undefined method `name' for nil:NilClass
     # ./src/specs/cpi_lifecycle_spec.rb:8:in `rescue in with_cpi'
     # ./src/specs/cpi_lifecycle_spec.rb:6:in `with_cpi'
     # ./src/specs/cpi_lifecycle_spec.rb:77:in `block (2 levels) in <top (required)>'
     # ./lib/validator/cli/cf_openstack_validator.rb:211:in `block (2 levels) in execute_specs'
     # ./lib/validator/cli/cf_openstack_validator.rb:210:in `open'
     # ./lib/validator/cli/cf_openstack_validator.rb:210:in `block in execute_specs'
     # ./lib/validator/cli/cf_openstack_validator.rb:174:in `with_environment'
     # ./lib/validator/cli/cf_openstack_validator.rb:196:in `execute_specs'
     # ./lib/validator/cli/cf_openstack_validator.rb:21:in `run'
     # ------------------
     # --- Caused by: ---
     # NoMethodError:
     #   undefined method `name' for nil:NilClass
     #   ./lib/validator/api/resource_tracker.rb:127:in `produce'

Finished in 1 minute 42.53 seconds (files took 0.09803 seconds to load)
9 examples, 1 failure
```