### PR TITLE
Check that there is no remote security group configuered.

### DIFF
--- a/src/specs/openstack_api_spec.rb
+++ b/src/specs/openstack_api_spec.rb
@@ -62,7 +62,7 @@ openstack_suite.context 'API', position: 1, order: :global do
   def port_open?(direction, port, protocol, security_group)
     security_group = @network.security_groups.find { |sg| sg.name == security_group }
     rule = security_group.security_group_rules.find { |rule|
-      rule.direction == direction && rule.ethertype == 'IPv4' && protocol_included?(rule, protocol) && port_in_range?(port, rule)
+      rule.direction == direction && rule.ethertype == 'IPv4' && protocol_included?(rule, protocol) && port_in_range?(port, rule) && rule.remote_group_id == nil
     }
     rule != nil
   end


### PR DESCRIPTION
Security rules can have a remoted_security group, that limits access
to instances with the configured security group. The default for the
'default' security group is to have an ingres rule, that allows acces
for all tcp protocols, however limited to the default security group.
Access from outside is not allowed. However the test for ssh access
did not fail.