### PR TITLE
terraform - add optional prefix to name and

### DIFF
--- a/ci/terraform/validator.tf
+++ b/ci/terraform/validator.tf
@@ -14,7 +14,7 @@ provider "openstack" {
 
 resource "openstack_compute_keypair_v2" "openstack_default_key_name" {
   region     = "${var.region_name}"
-  name       = "${var.tenant_name}-validator"
+  name       = "${var.name_prefix}${var.tenant_name}-validator"
   public_key = "${var.openstack_default_key_public_key}"
 }
 
@@ -22,21 +22,21 @@ resource "openstack_compute_keypair_v2" "openstack_default_key_name" {
 
 resource "openstack_networking_network_v2" "validator_net" {
   region         = "${var.region_name}"
-  name           = "validator"
+  name           = "${var.name_prefix}validator"
   admin_state_up = "true"
 }
 
 resource "openstack_networking_subnet_v2" "validator_sub" {
   region           = "${var.region_name}"
   network_id       = "${openstack_networking_network_v2.validator_net.id}"
-  cidr             = "10.0.1.0/24"
+  cidr             = "${var.net_cidr}"
   ip_version       = 4
-  name             = "validator_sub"
+  name             = "${var.name_prefix}validator_sub"
   allocation_pools = {
-    start = "10.0.1.200"
-    end   = "10.0.1.254"
+    start = "${var.allocation_pool_start}"
+    end = "${var.allocation_pool_end}"
   }
-  gateway_ip       = "10.0.1.1"
+  gateway_ip       = "${var.gateway_ip}"
   enable_dhcp      = "true"
   dns_nameservers = ["${compact(split(",",var.dns_nameservers))}"]
 }
@@ -45,7 +45,7 @@ resource "openstack_networking_subnet_v2" "validator_sub" {
 
 resource "openstack_networking_router_v2" "default_router" {
   region           = "${var.region_name}"
-  name             = "validator-router"
+  name             = "${var.name_prefix}validator-router"
   admin_state_up   = "true"
   external_gateway = "${var.ext_net_id}"
 }
@@ -65,7 +65,7 @@ resource "openstack_compute_floatingip_v2" "validator_floating_ip" {
 
 resource "openstack_networking_secgroup_v2" "validator_secgroup" {
   region      = "${var.region_name}"
-  name        = "validator"
+  name        = "${var.name_prefix}validator"
   description = "validator security group"
 }
 

--- a/ci/terraform/vars.tf
+++ b/ci/terraform/vars.tf
@@ -26,6 +26,31 @@ variable "insecure" {
    description = "SSL certificate validation"
 }
 
+variable "name_prefix" {
+   default = ""
+   description = "Prefix for names of infrastucture components"
+}
+
+variable "net_cidr" {
+   default = "10.0.1.0/24"
+   description = "CIDR of validator subnet"
+}
+
+variable "allocation_pool_start" {
+  default = "10.0.1.200"
+  description = "Allocation pool start"
+}
+
+variable "allocation_pool_end" {
+  default = "10.0.1.254"
+  description = "Allocation pool end"
+}
+
+variable "gateway_ip" {
+  default= "10.0.1.1"
+  description = "Default gateway"
+}
+
 variable "cacert_file" {
   default = ""
   description = "CA File"


### PR DESCRIPTION
make subnet ip range configurable.

This change is useful, in order to avoid name conflicts in openstack tenants.
The added variables have the original values as default.
Infrastructure resources can be left intact for further analysis, while other tests are are running.
