### PR TITLE
Explicitely list/filter entities by project

### DIFF
--- a/ci/tasks/cleanup.sh
+++ b/ci/tasks/cleanup.sh
@@ -6,6 +6,8 @@ source validator-src/ci/tasks/utils.sh
 
 init_openstack_cli_env
 
+OPENSTACK_PROJECT_ID=$(openstack project show $BOSH_OPENSTACK_PROJECT -c id -f value)
+
 exit_code=0
 
 openstack_delete_entities() {
@@ -22,7 +24,7 @@ openstack_delete_entities() {
 }
 
 openstack_delete_ports() {
-  for port in $(openstack port list --format json | jq --raw-output '.[].ID')
+  for port in $(neutron port-list -c id --project_id=$OPENSTACK_PROJECT_ID -f value)
   do
 
   # don't delete ports that are:
@@ -46,9 +48,9 @@ echo "openstack cli version:"
 openstack --version
 
 echo "Deleting servers #########################"
-openstack_delete_entities "server"
+openstack_delete_entities "server" "--project $OPENSTACK_PROJECT_ID"
 echo "Deleting images #########################"
-openstack_delete_entities "image" "--private --limit 1000"
+openstack_delete_entities "image" "--private --limit 1000 --property owner=$OPENSTACK_PROJECT_ID"
 echo "Deleting snapshots #########################"
 openstack_delete_entities "snapshot"
 echo "Deleting volumes #########################"


### PR DESCRIPTION
The script is dangerous. If the user running the CFOV has an admin role
on the project the validator runs in, the cleanup script will find all
glance images and all neutron ports.
The list commands filters by default on the project for servers, volumes
and snapshot.
I added the project filter explicitely for servers, images and ports.
(For volumes there is also a `--project` option, but passing this did
not worked for me with the cleanup script.)

And yes openstack CLIs are great as they are everything else then
consistent across projects :)