### PR TITLE
Explicitely list/filter entities by project

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -33,6 +33,7 @@ jobs:
         BOSH_OPENSTACK_API_KEY:              ((api_key))
         BOSH_OPENSTACK_PROJECT:              ((project))
         BOSH_OPENSTACK_CA_CERT:              ((ca_cert))
+        BOSH_OPENSTACK_INTERFACE:            ((interface))
 
 - name: test
   build_logs_to_retain: *build_logs_to_retain

--- a/ci/tasks/cleanup.sh
+++ b/ci/tasks/cleanup.sh
@@ -24,7 +24,7 @@ openstack_delete_entities() {
 }
 
 openstack_delete_ports() {
-  for port in $(neutron port-list -c id --project_id=$OPENSTACK_PROJECT_ID -f value)
+  for port in $(openstack port list --project=$OPENSTACK_PROJECT_ID -c ID -f value)
   do
 
   # don't delete ports that are:

--- a/ci/tasks/cleanup.sh
+++ b/ci/tasks/cleanup.sh
@@ -6,6 +6,8 @@ source validator-src/ci/tasks/utils.sh
 
 init_openstack_cli_env
 
+OPENSTACK_PROJECT_ID=$(openstack project show $BOSH_OPENSTACK_PROJECT -c id -f value)
+
 exit_code=0
 
 openstack_delete_entities() {
@@ -22,7 +24,7 @@ openstack_delete_entities() {
 }
 
 openstack_delete_ports() {
-  for port in $(openstack port list --format json | jq --raw-output '.[].ID')
+  for port in $(neutron port-list -c id --project_id=$OPENSTACK_PROJECT_ID -f value)
   do
 
   # don't delete ports that are:
@@ -48,7 +50,7 @@ openstack --version
 echo "Deleting servers #########################"
 openstack_delete_entities "server"
 echo "Deleting images #########################"
-openstack_delete_entities "image" "--private --limit 1000"
+openstack_delete_entities "image" "--private --limit 1000 --property owner=$OPENSTACK_PROJECT_ID"
 echo "Deleting snapshots #########################"
 openstack_delete_entities "snapshot"
 echo "Deleting volumes #########################"

--- a/ci/tasks/cleanup.yml
+++ b/ci/tasks/cleanup.yml
@@ -15,3 +15,4 @@ params:
   BOSH_OPENSTACK_API_KEY:              replace-me
   BOSH_OPENSTACK_PROJECT:              replace-me
   BOSH_OPENSTACK_CA_CERT:              replace-me
+  BOSH_OPENSTACK_INTERFACE:            replace-me

--- a/ci/tasks/utils.sh
+++ b/ci/tasks/utils.sh
@@ -15,6 +15,7 @@ init_openstack_cli_env(){
     : ${BOSH_OPENSTACK_API_KEY:?}
     : ${BOSH_OPENSTACK_PROJECT:?}
     : ${BOSH_OPENSTACK_DOMAIN_NAME:?}
+    : ${BOSH_OPENSTACK_INTERFACE:?}
     optional_value BOSH_OPENSTACK_CA_CERT
 
     export OS_DEFAULT_DOMAIN=$BOSH_OPENSTACK_DOMAIN_NAME
@@ -25,6 +26,7 @@ init_openstack_cli_env(){
     export OS_VOLUME_API_VERSION=1
     export OS_DOMAIN_NAME=$BOSH_OPENSTACK_DOMAIN_NAME
     export OS_IDENTITY_API_VERSION=3
+    export OS_INTERFACE=$BOSH_OPENSTACK_INTERFACE
 
     if [ -n "$BOSH_OPENSTACK_CA_CERT" ]; then
       tmpdir=$(mktemp -dt "$(basename $0).XXXXXXXXXX")


### PR DESCRIPTION
The script is dangerous. If the user running the CFOV has an admin role
on the project the validator runs in, the cleanup script will find all
glance images and all neutron ports.
The list commands filters by default on the project for servers, volumes
and snapshot.
This patch adds the project filter explicitely for images and ports.
(For volumes there is also a `--project` option, but passing this did
not worked for me with the cleanup script.)

And yes openstack CLIs are great as they are everything else then
consistent across projects :)