### PR TITLE
Bump fog-openstack to 0.1.24

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'fog-openstack', '=0.1.23-microversions'
+gem 'fog-openstack', '=0.1.24'
 gem 'excon', '~>0.49.0'
 gem 'rspec', '~> 3.5.0'
 gem 'membrane', '~> 1.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,8 @@ GEM
     fog-json (1.0.2)
       fog-core (~> 1.0)
       multi_json (~> 1.10)
-    fog-openstack (0.1.23.pre.microversions)
-      fog-core (>= 1.40)
+    fog-openstack (0.1.24)
+      fog-core (~> 1.40)
       fog-json (>= 1.0)
       ipaddress (>= 0.8)
     formatador (0.2.5)
@@ -38,7 +38,7 @@ PLATFORMS
 
 DEPENDENCIES
   excon (~> 0.49.0)
-  fog-openstack (= 0.1.23.pre.microversions)
+  fog-openstack (= 0.1.24)
   membrane (~> 1.1.0)
   rspec (~> 3.5.0)
 


### PR DESCRIPTION
Due to error in fog-openstack 0.1.23 (see more here https://github.com/fog/fog-openstack/issues/356)