### PR TITLE
add workdir parameter to cli

### DIFF
--- a/bin/cf-openstack-validator
+++ b/bin/cf-openstack-validator
@@ -4,6 +4,7 @@ require 'optparse'
 require_relative '../lib/validator/cli'
 
 cli_options = {}
+working_dir = "#{ENV['HOME']}/.cf-openstack-validator"
 required_options = {stemcell: '--stemcell', config_path: '--config'}
 option_parser = OptionParser.new do |parser|
   parser.banner = 'Usage: cf-openstack-validator [options]'
@@ -40,6 +41,11 @@ option_parser = OptionParser.new do |parser|
   parser.on('-f', '--fail-fast', 'Stop execution after the first test failure (optional)') do
     cli_options[:fail_fast] = true
   end
+
+  parser.on('-w', "--working-dir WORKING_DIR", 'Working directory for running the tests') do |workdir|
+    working_dir = workdir
+  end
+
 end
 option_parser.parse!
 
@@ -53,6 +59,6 @@ unless missing_required_options.empty?
   exit 1
 end
 
-context = Validator::Cli::Context.new(cli_options)
+context = Validator::Cli::Context.new(cli_options, working_dir)
 validator = Validator::Cli::CfOpenstackValidator.create(context)
 validator.run

--- a/bin/cf-openstack-validator
+++ b/bin/cf-openstack-validator
@@ -42,10 +42,9 @@ option_parser = OptionParser.new do |parser|
     cli_options[:fail_fast] = true
   end
 
-  parser.on('-w', "--working-dir WORKING_DIR", 'Working directory for running the tests') do |workdir|
-    working_dir = workdir
+  parser.on('-w', "--working-dir WORKING_DIR", 'Working directory for running the tests (optional)') do |workdir|
+    cli_options[:working_dir] = workdir
   end
-
 end
 option_parser.parse!
 

--- a/lib/validator/cli/context.rb
+++ b/lib/validator/cli/context.rb
@@ -7,10 +7,10 @@ module Validator::Cli
 
     attr_accessor :cpi_bin_path, :cpi_release_path
 
-    def initialize(cli_options, working_dir = "#{ENV['HOME']}/.cf-openstack-validator")
+    def initialize(cli_options)
       @cli_options = cli_options
       @cpi_release_path = @cli_options[:cpi_release]
-      @working_dir = working_dir
+      @working_dir = @cli_options[:working_dir] || "#{ENV['HOME']}/.cf-openstack-validator"
       ensure_working_directory(@working_dir)
       @path_from_env = ENV['PATH']
       @openstack_cpi_bin_from_env = ENV['OPENSTACK_CPI_BIN']
@@ -22,7 +22,7 @@ module Validator::Cli
     end
 
     def tag
-     @cli_options[:tag]
+      @cli_options[:tag]
     end
 
     def skip_cleanup?

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -18,6 +18,7 @@ Usage: cf-openstack-validator [options]
     -k, --skip-cleanup               Skip cleanup of OpenStack resources (optional)
     -v, --verbose                    Print more output for failing tests (optional)
     -f, --fail-fast                  Stop execution after the first test failure (optional)
+    -w, --working-dir WORKING_DIR    Working directory for running the tests (optional)
 EOT
 end
 

--- a/spec/unit/validator/cli/cf_openstack_validator_spec.rb
+++ b/spec/unit/validator/cli/cf_openstack_validator_spec.rb
@@ -7,7 +7,8 @@ module Validator::Cli
     let(:jobs_config_path) { File.join(working_dir, 'jobs', 'openstack_cpi', 'config') }
 
     let(:options) {{cpi_release: release_archive_path, stemcell: expand_project_path('spec/assets/dummy.tgz')}}
-    let(:context) { Context.new(options, working_dir) }
+    let(:default_options) {{working_dir: working_dir}}
+    let(:context) { Context.new(options.merge(default_options)) }
     subject { CfOpenstackValidator.new(context) }
 
     let(:release_archive_path) { expand_project_path('spec/assets/cpi-release.tgz') }

--- a/spec/unit/validator/cli/context_spec.rb
+++ b/spec/unit/validator/cli/context_spec.rb
@@ -2,9 +2,14 @@ require_relative '../../spec_helper'
 
 module Validator::Cli
   describe Context do
-    let(:cli_options) { {} }
-    let(:subject) { Context.new(cli_options, working_directory) }
     let(:working_directory) { Dir.mktmpdir }
+    let(:default_options) {
+      {working_dir: working_directory}
+    }
+    let(:cli_options) { {} }
+    let(:subject) {
+      Context.new(cli_options.merge(default_options))
+    }
 
     after(:each) do
       if File.exists?(working_directory)
@@ -56,7 +61,7 @@ module Validator::Cli
           FileUtils.touch(path)
 
           expect {
-            Context.new(cli_options, path)
+            Context.new(cli_options.merge({working_dir: path}))
           }.to raise_error Errno::EEXIST
         end
       end


### PR DESCRIPTION
as discussed with @voelzmo, adding this parameter to the cli allows to execute multiple instances of the cf-openstack-validator in parallel 