### PR TITLE
Do not deleted DVR ports

### DIFF
--- a/ci/tasks/cleanup.sh
+++ b/ci/tasks/cleanup.sh
@@ -7,6 +7,10 @@ source validator-src-in/ci/tasks/utils.sh
 init_openstack_cli_env
 
 OPENSTACK_PROJECT_ID=$(openstack project list --format json | jq --raw-output --arg project $BOSH_OPENSTACK_PROJECT '.[] | select(.Name == $project) | .ID')
+if [ -z "$OPENSTACK_PROJECT_ID" ]; then
+  echo "Error: Failed to get OpenStack project"
+  exit 1
+fi
 
 exit_code=0
 
@@ -33,9 +37,10 @@ openstack_delete_ports() {
   # 'network:floatingip', 'network:router_gateway',
   # 'network:dhcp', 'network:router_interface',
   # 'network:ha_router_replicated_interface',
+  # 'network:router_interface_distributed',
   # 'neutron:LOADBALANCERV2' and 'network:f5lbaasv2'
   # Maybe we could just filter for 'network:'?
-    port_to_be_deleted=`openstack port show --format json $port | jq --raw-output '. | select(.device_owner | contains("network:floatingip") or contains("network:router_gateway") or contains("network:dhcp") or contains("network:router_interface") or contains("network:ha_router_replicated_interface") or contains("neutron:LOADBALANCERV2") or contains("network:f5lbaasv2") or contains("network:router_centralized_snat") | not ) | .id'`
+    port_to_be_deleted=`openstack port show --format json $port | jq --raw-output '. | select(.device_owner | contains("network:floatingip") or contains("network:router_gateway") or contains("network:dhcp") or contains("network:router_interface") or contains("network:ha_router_replicated_interface") or contains("neutron:LOADBALANCERV2") or contains("network:f5lbaasv2") or contains("network:router_centralized_snat") or contains("network:router_interface_distributed") | not ) | .id'`
     if [ ! -z ${port_to_be_deleted} ];
     then
       echo "Deleting port ${port_to_be_deleted}"


### PR DESCRIPTION
DVR ports have the device_owner 'network:router_interface_distributed'.

Additionally: exit, if we cannot fetch OpenStack project ID. This prevents deleting
resources, that belong to other projects, if the script runs with admin
privileges.